### PR TITLE
make compatible with superwow

### DIFF
--- a/logic/profession.lua
+++ b/logic/profession.lua
@@ -212,6 +212,9 @@ MTSL_LOGIC_PROFESSION = {
             if skill_type ~= "header" then
                 local itemLink = GetCraftItemLink(i)
                 local itemID = string.gfind(itemLink, "enchant:(%d+)")()
+                if SetAutoloot then --is superwow active?
+                    itemID = string.gfind(itemLink, "spell:(%d+)")() --superwow uses spell: instead of enchant: in its item links
+                end
                 table.insert(learned_skill_ids, itemID)
             end
         end


### PR DESCRIPTION
Superwow uses a different itemlink format for enchants than turtlewow, making it incompatible. Turtle uses `enchant:` while superwow uses generic `spell:`. Compatibility with twow's format is maintained when superwow is not found.